### PR TITLE
ปรับธีมเป็นโทนสีฟ้า

### DIFF
--- a/lib/MoneyBox.dart
+++ b/lib/MoneyBox.dart
@@ -4,7 +4,8 @@ import 'package:flutter/material.dart';
 class MoneyBox extends StatelessWidget {
   String title = ""; // ชื่อหมวดหมู่/รายการ
   double amount = 0; //จำนวนเงิน
-  Color color = Colors.red; //สีของกล่อง
+  // Default to a pleasant blue tone
+  Color color = Colors.lightBlue; //สีของกล่อง
   double size = 0; //ขนาดของกล่อง
 
   MoneyBox(this.title, this.amount, this.color, this.size);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,7 +13,8 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: "My App",
       home: MyHomePage(),
-      theme: ThemeData(primarySwatch: Colors.blue),
+      // Update the theme to a lighter blue shade
+      theme: ThemeData(primarySwatch: Colors.lightBlue),
     );
   }
 }
@@ -52,7 +53,9 @@ class _MyHomePageState extends State<MyHomePage> {
           MoneyBox("ยอดคงเหลือ", 10000.41, Colors.lightBlue, 120),
           Container(
             decoration: BoxDecoration(
-                color: Colors.red, borderRadius: BorderRadius.circular(10)),
+                // Use a pleasant blue tone instead of red
+                color: Colors.lightBlue,
+                borderRadius: BorderRadius.circular(10)),
             height: 100,
             child: Padding(
               padding: const EdgeInsets.all(8.0),
@@ -79,12 +82,16 @@ class _MyHomePageState extends State<MyHomePage> {
           ),
           Container(
             decoration: BoxDecoration(
-                color: Colors.green, borderRadius: BorderRadius.circular(10)),
+                // Replace green with a consistent blue shade
+                color: Colors.lightBlueAccent,
+                borderRadius: BorderRadius.circular(10)),
             height: 100,
           ),
           Container(
             decoration: BoxDecoration(
-                color: Colors.blue, borderRadius: BorderRadius.circular(10)),
+                // Slightly brighter blue box
+                color: Colors.blueAccent,
+                borderRadius: BorderRadius.circular(10)),
             height: 100,
           )
         ]),


### PR DESCRIPTION
## Summary
- เปลี่ยนค่า primary swatch ให้เป็นโทนสีฟ้าอ่อน
- ปรับกล่องและวิดเจ็ตต่าง ๆ ให้ใช้สีฟ้าแทนสีเดิม
- กำหนดสีเริ่มต้นของ `MoneyBox` เป็นสีฟ้า

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685791d1eb2c832ea50beaa2ec33df69